### PR TITLE
Resolve Compilation Failure Due to Missing numpy/arrayobject.h

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ class SuperBuildExt(build_ext):
         #  We delay it for the setup to raise a nice error if numpy is not found.
         #  https://stackoverflow.com/questions/54117786
         import numpy
+        self.include_dirs.append(numpy.get_include())
         print("cimporting numpy version '%s'", numpy.__version__)
 
 


### PR DESCRIPTION
This merge request introduces a fix to the build process, addressing a compilation failure that occurs when numpy is not installed in the global Python environment. The issue manifests as a missing header file (`numpy/arrayobject.h`), leading to a failure during the compilation of `funshade.c`.

**Problem Description**
During the build process, in an environment without a global installation of numpy, the compiler raises a fatal error due to the absence of numpy/arrayobject.h. This issue arises because the build process previously assumed access to numpy's include directories without explicitly specifying them. The error log is as follows:
```
Processing /home/philipp/tmp/funshade
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: numpy>=1.21 in ./env/lib/python3.11/site-packages (from Funshade==1.0.2) (1.26.4)
Building wheels for collected packages: Funshade
  Building wheel for Funshade (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for Funshade (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [13 lines of output]
      running bdist_wheel
      running build
      running build_ext
      cimporting numpy version '%s' 1.26.4
      building 'funshade' extension
      gcc -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -ffat-lto-objects -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -D__PYX_ENUM_CLASS_DECL=enum -I/home/philipp/tmp/funshade/funshade/c -I/home/philipp/tmp/funshade/env/include -I/usr/include/python3.11 -c funshade/c/aes.c -o build/temp.linux-x86_64-3.11/funshade/c/aes.o -O3 -msse -msse2 -maes -march=native
      gcc -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -ffat-lto-objects -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -D__PYX_ENUM_CLASS_DECL=enum -I/home/philipp/tmp/funshade/funshade/c -I/home/philipp/tmp/funshade/env/include -I/usr/include/python3.11 -c funshade/c/fss.c -o build/temp.linux-x86_64-3.11/funshade/c/fss.o -O3 -msse -msse2 -maes -march=native
      gcc -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -ffat-lto-objects -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -D__PYX_ENUM_CLASS_DECL=enum -I/home/philipp/tmp/funshade/funshade/c -I/home/philipp/tmp/funshade/env/include -I/usr/include/python3.11 -c funshade/py/funshade.c -o build/temp.linux-x86_64-3.11/funshade/py/funshade.o -O3 -msse -msse2 -maes -march=native
      funshade/py/funshade.c:1103:10: fatal error: numpy/arrayobject.h: No such file or directory
       1103 | #include "numpy/arrayobject.h"
            |          ^~~~~~~~~~~~~~~~~~~~~
      compilation terminated.
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for Funshade
Failed to build Funshade
ERROR: Could not build wheels for Funshade, which is required to install pyproject.toml-based projects
```

**Reproduce the error**
1. Clone repo
2. `python -m venv env`
3. `source env/bin/activate`
4. `pip install .`

**Solution**
To address this issue, the proposed change adds a single line of code:
`self.include_dirs.append(numpy.get_include())`

This addition dynamically appends numpy's include directory to the include_dirs list during the build process. By integrating this line, we ensure that the compiler can locate the necessary numpy header files, regardless of numpy's installation scope (global or virtual environment).